### PR TITLE
Remove unused Chromagram from network

### DIFF
--- a/src/ofxMLTK.cpp
+++ b/src/ofxMLTK.cpp
@@ -736,7 +736,6 @@ void MLTK::connectAlgorithmStream(essentia::streaming::AlgorithmFactory& factory
   algorithms["FrameCutter"]->output("frame") >> algorithms["Windowing"]->input("frame");
   algorithms["Windowing"]->output("frame") >> algorithms["RMS"]->input("array");
   algorithms["Windowing"]->output("frame") >> algorithms["Spectrum"]->input("frame");
-  algorithms["Windowing"]->output("frame") >> algorithms["Chromagram"]->input("frame");
   algorithms["Spectrum"]->output("spectrum")  >> algorithms["MFCC"]->input("spectrum");
   algorithms["Spectrum"]->output("spectrum") >> algorithms["SpectralPeaks"]->input("spectrum");
   algorithms["SpectralPeaks"]->output("frequencies") >> algorithms["HPCP"]->input("frequencies");


### PR DESCRIPTION
This line causes MLTK to fail at runtime because there is no sink for Chromagram. I think we should remove it for now.